### PR TITLE
nodemon shouldn't be installed as global dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ws": "^7.2.1"
   },
   "devDependencies": {
-    "concurrently": "^3.6.0"
+    "concurrently": "^3.6.0",
+    "nodemon": "^2.0.2"
   }
 }


### PR DESCRIPTION
Adding nodemon as dev dependency in the package.json should enable users to run this code without have to figure out why npm start return errors.

BTW, yarn doens't come with node by default... so a disclaimer should appear somewhere in the readme.